### PR TITLE
Updated to work with NDI SDK version 2. Not backwards compatible with…

### DIFF
--- a/src/ofxNDIreceiver.cpp
+++ b/src/ofxNDIreceiver.cpp
@@ -260,38 +260,44 @@ bool ofxNDIreceiver::GetSenderName(char *sendername, int userindex)
 
 bool ofxNDIreceiver::CreateReceiver(int userindex)
 {
-	if(!bNDIinitialized) return false;
+	// Default to BGRA if no format color format is specified
+	return CreateReceiver(NDIlib_recv_color_format_e_BGRX_BGRA,userindex);
+}
 
-	int index = userindex; 
+bool ofxNDIreceiver::CreateReceiver(NDIlib_recv_color_format_e colorFormat , int userindex)
+{
+	if (!bNDIinitialized) return false;
 
-	if(!pNDI_recv) {
+	int index = userindex;
+
+	if (!pNDI_recv) {
 
 		// The continued check in FindSenders is for a network change and
 		// p_sources is returned NULL, so we need to find all the sources
 		// again to get a pointer to the selected sender.
 		// Give it a timeout in case of connection trouble.
-		if(pNDI_find) {
+		if (pNDI_find) {
 			dwStartTime = timeGetTime();
 			do {
 				p_sources = NDIlib_find_get_sources(pNDI_find, &no_sources, 0);
 				dwElapsedTime = timeGetTime() - dwStartTime;
-			} while(no_sources == 0 && dwElapsedTime < 4000); 
+			} while (no_sources == 0 && dwElapsedTime < 4000);
 		}
 		// TODO - reset sender name vector?
-		
-		if(p_sources && no_sources > 0) {
+
+		if (p_sources && no_sources > 0) {
 
 			// If no index has been specified, use the currently set index
-			if(userindex < 0) 
+			if (userindex < 0)
 				index = senderIndex;
 
 			// We tell it that we prefer BGRA
 			// TODO : does "prefer" mean we might get YUV as well ?
 			// NDIlib_recv_create_t NDI_recv_create_desc = { p_sources[senderIndex], FALSE };
 			// 16-06-16 - SDK change
-			NDIlib_recv_create_t NDI_recv_create_desc = { 
+			NDIlib_recv_create_t NDI_recv_create_desc = {
 				p_sources[index],
-				NDIlib_recv_color_format_BGRA_BGRA,
+				colorFormat,
 				NDIlib_recv_bandwidth_highest, // LJ DEBUG ? Allow fielded video
 				TRUE };
 
@@ -300,7 +306,7 @@ bool ofxNDIreceiver::CreateReceiver(int userindex)
 			if (!pNDI_recv) {
 				return false;
 			}
-			
+
 			// on_program = TRUE, on_preview = FALSE
 			const NDIlib_tally_t tally_state = { TRUE, FALSE };
 			NDIlib_recv_set_tally(pNDI_recv, &tally_state);

--- a/src/ofxNDIreceiver.h
+++ b/src/ofxNDIreceiver.h
@@ -49,6 +49,7 @@ public:
     ~ofxNDIreceiver();
 
 	bool CreateReceiver(int index = -1);
+	bool CreateReceiver(NDIlib_recv_color_format_e colorFormat, int index = -1);
 	void ReleaseReceiver();
 	bool ReceiveImage(unsigned char *pixels, 
 					  unsigned int &width, unsigned int &height, 
@@ -69,7 +70,8 @@ public:
 private:
 
 	const NDIlib_source_t* p_sources;
-	DWORD no_sources;
+	//DWORD no_sources; 
+	uint32_t no_sources;
 	NDIlib_send_create_t NDI_send_create_desc;
 	NDIlib_find_instance_t pNDI_find;
 	NDIlib_recv_instance_t pNDI_recv; 

--- a/src/ofxNDIsender.cpp
+++ b/src/ofxNDIsender.cpp
@@ -76,10 +76,14 @@ ofxNDIsender::ofxNDIsender()
 	}
 }
 
-
 bool ofxNDIsender::CreateSender(const char *sendername, unsigned int width, unsigned int height)
 {
+	return CreateSender(sendername, width, height, NDIlib_FourCC_type_BGRA);
+}
 
+
+bool ofxNDIsender::CreateSender(const char *sendername, unsigned int width, unsigned int height, NDIlib_FourCC_type_e colorFormat)
+{
 	// Create an NDI source that is clocked to the video.
 	// unless async sending has been selected.
 	NDI_send_create_desc.p_ndi_name = (const char *)sendername;
@@ -129,11 +133,14 @@ bool ofxNDIsender::CreateSender(const char *sendername, unsigned int width, unsi
 
 		video_frame.xres = width;
 		video_frame.yres = height;
-		video_frame.FourCC = NDIlib_FourCC_type_BGRA;
+		video_frame.FourCC = colorFormat;
 		video_frame.frame_rate_N = m_frame_rate_N; // clock the frame (default 60fps)
 		video_frame.frame_rate_D = m_frame_rate_D;
 		video_frame.picture_aspect_ratio = m_picture_aspect_ratio; // default source (width/height)
-		video_frame.is_progressive = m_bProgressive; // progressive of interlaced (default progressive)
+		// 24-1-17 SDK Change to NDI v2
+		//video_frame.is_progressive = m_bProgressive; // progressive of interlaced (default progressive)
+		if (m_bProgressive) video_frame.frame_format_type = NDIlib_frame_format_type_progressive;
+		else video_frame.frame_format_type = NDIlib_frame_format_type_interleaved;
 		// The timecode of this frame in 100ns intervals
 		video_frame.timecode = NDIlib_send_timecode_synthesize; // 0LL; // Let the API fill in the timecodes for us.
 		video_frame.p_data = NULL;

--- a/src/ofxNDIsender.h
+++ b/src/ofxNDIsender.h
@@ -46,6 +46,7 @@ public:
     ~ofxNDIsender();
 
 	bool CreateSender(const char *sendername, unsigned int width, unsigned int height);
+	bool CreateSender(const char *sendername, unsigned int width, unsigned int height, NDIlib_FourCC_type_e colorFormat);
 	bool UpdateSender(unsigned int width, unsigned int height);
 	void ReleaseSender();
 


### PR DESCRIPTION
… previous SDK due to no_sources variable type change from DWORD (unsigned long) to uint32_t

Perhaps you can see a nicer way of doing this. The examples will still work once the new NDI SDK includes and libs copied over.