### PR TITLE
from @leadedge testing branch, now compiling and running on linux

### DIFF
--- a/src/ofxNDIdynloader.cpp
+++ b/src/ofxNDIdynloader.cpp
@@ -3,6 +3,7 @@
 
 ofxNDIdynloader::ofxNDIdynloader()
 {
+    p_NDILib = nullptr;
 }
 
 ofxNDIdynloader::~ofxNDIdynloader()
@@ -31,7 +32,6 @@ const std::string ofxNDIdynloader::FindRuntime() {
 const NDIlib_v4* ofxNDIdynloader::Load()
 {
     std::string path = FindRuntime();
-    //path.append(SharedLibrary::suffix());   // adds ".dll" or ".so"
 
     dynlib.load(path, dll::load_mode::search_system_folders);
     if( dynlib.has("NDIlib_v4_load") ) {

--- a/src/ofxNDIdynloader.cpp
+++ b/src/ofxNDIdynloader.cpp
@@ -1,19 +1,15 @@
 #include "ofxNDIdynloader.h"
 #include "ofMain.h"
 
-#if defined(TARGET_WIN32)
-    #include <windows.h>
-    #include <shlwapi.h>  // for path functions
-    #include <Shellapi.h> // for shellexecute
-    #pragma comment(lib, "shlwapi.lib")  // for path functions
-    #pragma comment(lib, "Shell32.lib")  // for shellexecute
-#elif defined(TARGET_LINUX) || defined(TARGET_OSX)
-    #include <dlfcn.h> // dynamic library loading in Linux
-#endif
-
 ofxNDIdynloader::ofxNDIdynloader()
 {
-    m_bWasLoaded = false;
+}
+
+ofxNDIdynloader::~ofxNDIdynloader()
+{
+    if( dynlib.is_loaded() ) {
+        dynlib.unload();
+    }
 }
 
 const std::string ofxNDIdynloader::FindRuntime() {
@@ -31,130 +27,18 @@ const std::string ofxNDIdynloader::FindRuntime() {
     return rt;
 }
 
-#if defined(TARGET_OSX) || defined(TARGET_LINUX)
 // Dynamic loading of the NDI dlls to avoid needing to use the NDI SDK lib files
 const NDIlib_v4* ofxNDIdynloader::Load()
 {
-    // protect against loading the NDI dll again
-    if (m_bWasLoaded) {
-        return p_NDILib;
+    std::string path = FindRuntime();
+    //path.append(SharedLibrary::suffix());   // adds ".dll" or ".so"
+
+    dynlib.load(path, dll::load_mode::search_system_folders);
+    if( dynlib.has("NDIlib_v4_load") ) {
+        ofLogNotice() << "library has NDIlib_v4_load method";
     }
 
-    std::string ndi_path = FindRuntime();
-
-    // attempt to load the library and get a handle to it
-    void *hNDILib = dlopen(ndi_path.c_str(), RTLD_LOCAL | RTLD_LAZY);
-    if (!hNDILib) {
-        ofLogWarning() << "Couldn't load dynamic library at: " << ndi_path;
-        return nullptr;
-    }
-
-    // binding dynamic library
-    // see this for reference: https://raw.githubusercontent.com/Palakis/obs-ndi/master/src/obs-ndi.cpp
-    NDIlib_v4_load_ lib_load = reinterpret_cast<NDIlib_v4_load_>(dlsym(hNDILib, "NDIlib_v4_load"));
-
-    // if lib is loaded but couldn't bind, user probably needs to reinstall
-    if (!lib_load)
-    {
-        // unload the library
-        if (hNDILib) {
-            dlclose(hNDILib);
-        }
-        ofLogError() << "Please re-install the NewTek NDI Runtimes from " << NDILIB_REDIST_URL << " to use this application";
-        return nullptr;
-    }
-
-    p_NDILib = lib_load(); // this loads the library and returns a pointer to the dynamic binding
-    m_bWasLoaded = true;
-
+    NDIlib_v4_load_& lib_load = dynlib.get<typeof(NDIlib_v4_load_)>("NDIlib_v4_load");
+    p_NDILib = lib_load();
     return p_NDILib;
 }
-#elif defined(TARGET_WIN32)
-const NDIlib_v4* ofxNDIdynloader::load()
-{
-    // First look in the executable folder for the dlls
-    // in case they are distributed with the application.
-    char path[MAX_PATH];
-    DWORD dwSize = GetModuleFileNameA(NULL, path, sizeof(path));
-    if (dwSize > 0) {
-        PathRemoveFileSpecA(path); // Remove executable name
-        strcat_s(path, MAX_PATH, "\\");
-        strcat_s(path, MAX_PATH, NDILIB_LIBRARY_NAME);
-        // Does the dll file exist in the executable folder ?
-        if (PathFileExistsA(path)) {
-            // Use the exe path
-            ndi_path = path;
-        }
-        else {
-            // The dll does not exist in exe folder
-            // Check whether the NDI run-time is installed
-            char *p_ndi_runtime_v4 = NULL;
-            size_t nchars;
-            _dupenv_s((char **)&p_ndi_runtime_v4, &nchars, NDILIB_REDIST_FOLDER);
-            if (!p_ndi_runtime_v4) {
-                // The NDI run-time is not yet installed. Let the user know and take them to the download URL.
-                MessageBoxA(NULL, "The NewTek NDI run-time is not yet installed\nPlease install it to use this application", "Warning.", MB_OK);
-                ShellExecuteA(NULL, "open", NDILIB_REDIST_URL, 0, 0, SW_SHOWNORMAL);
-                return false;
-            }
-            // Get the full path of the installed dll
-            ndi_path = p_ndi_runtime_v4;
-            ndi_path += "\\" NDILIB_LIBRARY_NAME;
-            free(p_ndi_runtime_v4); // free the buffer allocated by _dupenv_s
-        }
-        // Now we have the DLL path
-        // printf("Path [%s]\n", ndi_path.c_str());
-    }
-
-    // Try to load the library
-    hNDILib = LoadLibraryA(ndi_path.c_str());
-    if (!hNDILib) {
-        MessageBoxA(NULL, "NDI library failed to load\nPlease re-install the NewTek NDI Runtimes\nfrom " NDILIB_REDIST_URL " to use this application", "Warning", MB_OK);
-        ShellExecuteA(NULL, "open", NDILIB_REDIST_URL, 0, 0, SW_SHOWNORMAL);
-        return false;
-    }
-
-    // The main NDI entry point for dynamic loading if we got the library
-    const NDIlib_v4* (*NDIlib_v4_load)(void) = NULL;
-    *((FARPROC*)&NDIlib_v4_load) = GetProcAddress(hNDILib, "NDIlib_v4_load");
-
-    // If we failed to load the library then we tell people to re-install it
-    if (!NDIlib_v4_load)
-    {	// Unload the DLL if we loaded it
-        if (hNDILib)
-            FreeLibrary(hNDILib);
-        // The NDI run-time is not installed correctly. Let the user know and take them to the download URL.
-        MessageBoxA(NULL, "Failed to find Version 4 NDI library\nPlease use the correct dll files\nor re-install the NewTek NDI Runtimes to use this application", "Warning", MB_OK);
-        ShellExecuteA(NULL, "open", NDILIB_REDIST_URL, 0, 0, SW_SHOWNORMAL);
-        return false;
-    }
-
-    // Get all of the DLL entry points
-    p_NDILib = NDIlib_v4_load();
-    if (!p_NDILib) {
-        MessageBoxA(NULL, "Failed to load Version 4 NDI library\nPlease use the correct dll files\nor re-install the NewTek NDI Runtimes to use this application", "Warning", MB_OK);
-        ShellExecuteA(NULL, "open", NDILIB_REDIST_URL, 0, 0, SW_SHOWNORMAL);
-        return false;
-    }
-
-    // Check cpu compatibility
-    if (!p_NDILib->is_supported_CPU()) {
-        MessageBoxA(NULL, "CPU does not support NDI NDILib requires SSE4.1 NDIreceiver", "Warning", MB_OK);
-        if (hNDILib)
-            FreeLibrary(hNDILib);
-        return false;
-    }
-    else {
-        if (!p_NDILib->initialize()) {
-            MessageBoxA(NULL, "Cannot run NDI - NDILib initialization failed", "Warning", MB_OK);
-            if (hNDILib)
-                FreeLibrary(hNDILib);
-            return false;
-        }
-        m_bNDIinitialized = true;
-    }
-
-    return true;
-}
-#endif
-

--- a/src/ofxNDIdynloader.cpp
+++ b/src/ofxNDIdynloader.cpp
@@ -33,7 +33,6 @@
 	06-12.19	- Revise for cross-platform without OF dependence
 
 */
-
 #include "ofxNDIdynloader.h"
 
 #include <iostream> // for cout
@@ -43,6 +42,7 @@ using namespace std;
 ofxNDIdynloader::ofxNDIdynloader()
 {
 	p_NDILib = nullptr;
+    m_bIsLoaded = false;
 #if defined(TARGET_WIN32)
 	m_hNDILib = NULL;
 #endif
@@ -54,6 +54,7 @@ ofxNDIdynloader::~ofxNDIdynloader()
 #if defined(TARGET_WIN32)
 	if (m_hNDILib) FreeLibrary(m_hNDILib);
 #endif
+    m_bIsLoaded = false;
 }
 
 #if defined(TARGET_WIN32)
@@ -144,27 +145,37 @@ const NDIlib_v4* ofxNDIdynloader::Load()
 		}
 	}
 
-	return p_NDILib;
+    m_bIsLoaded = true;
+    return p_NDILib;
 }
-#elif defined(TARGET_OSX) || defined(TARGET_LINUX)
+#endif
+
+const std::string ofxNDIdynloader::FindRuntime() {
+    std::string rt;
+
+    const char* p_NDI_runtime_folder = getenv(NDILIB_REDIST_FOLDER);
+    if (p_NDI_runtime_folder)
+    {
+        rt = p_NDI_runtime_folder;
+        rt += NDILIB_LIBRARY_NAME;
+    }
+    else rt = NDILIB_LIBRARY_NAME;
+
+    return rt;
+}
+
+#if defined(TARGET_OSX) || defined(TARGET_LINUX)
 // OSX and LINUX
 const NDIlib_v4* ofxNDIdynloader::Load()
 {
  
-	std::string ndi_path;
-	const char* p_NDI_runtime_folder = getenv(NDILIB_REDIST_FOLDER);
-	cout << "NDI runtime location " << p_NDI_runtime_folder << endl;
-	if (p_NDI_runtime_folder) {
-		ndi_path = p_NDI_runtime_folder;
-		ndi_path += NDILIB_LIBRARY_NAME;
-	}
-	else
-		ndi_path = NDILIB_LIBRARY_NAME;
+    std::string ndi_path = FindRuntime();
+    OUTS << "NDI runtime location " << ndi_path << endl;
 
     // attempt to load the library and get a handle to it
     void *m_hNDILib = dlopen(ndi_path.c_str(), RTLD_LOCAL | RTLD_LAZY);
     if (!m_hNDILib) {
-        cout << "Couldn't load dynamic library at: " << ndi_path << endl;
+        ERRS << "Couldn't load dynamic library at: " << ndi_path << endl;
         return nullptr;
     }
 
@@ -180,12 +191,12 @@ const NDIlib_v4* ofxNDIdynloader::Load()
             dlclose(m_hNDILib);
 			m_hNDILib = NULL;
         }
-		cout << "Please re-install the NewTek NDI Runtimes from " << NDILIB_REDIST_URL << " to use this application" << endl;
+        WARNS << "Please re-install the NewTek NDI Runtimes from " << NDILIB_REDIST_URL << " to use this application" << endl;
         return nullptr;
     }
 
     p_NDILib = lib_load(); // this loads the library and returns a pointer to the dynamic binding
-
+    m_bIsLoaded = true;
     return p_NDILib;
 }
 #else

--- a/src/ofxNDIdynloader.cpp
+++ b/src/ofxNDIdynloader.cpp
@@ -35,6 +35,7 @@
 */
 
 #include "ofxNDIdynloader.h"
+
 #include <iostream> // for cout
 
 using namespace std;
@@ -42,7 +43,7 @@ using namespace std;
 ofxNDIdynloader::ofxNDIdynloader()
 {
 	p_NDILib = nullptr;
-#if defined(_WIN32)
+#if defined(TARGET_WIN32)
 	m_hNDILib = NULL;
 #endif
 }
@@ -50,12 +51,12 @@ ofxNDIdynloader::ofxNDIdynloader()
 ofxNDIdynloader::~ofxNDIdynloader()
 {
 	if (p_NDILib) p_NDILib->destroy();
-#if defined(_WIN32)
+#if defined(TARGET_WIN32)
 	if (m_hNDILib) FreeLibrary(m_hNDILib);
 #endif
 }
 
-#if defined(_WIN32)
+#if defined(TARGET_WIN32)
 const NDIlib_v4* ofxNDIdynloader::Load()
 {
 	std::string ndi_path;
@@ -145,7 +146,7 @@ const NDIlib_v4* ofxNDIdynloader::Load()
 
 	return p_NDILib;
 }
-#elif defined(__APPLE__) || defined(__linux__)
+#elif defined(TARGET_OSX) || defined(TARGET_LINUX)
 // OSX and LINUX
 const NDIlib_v4* ofxNDIdynloader::Load()
 {
@@ -188,6 +189,9 @@ const NDIlib_v4* ofxNDIdynloader::Load()
     return p_NDILib;
 }
 #else
-return nullptr;
+const NDIlib_v4* ofxNDIdynloader::Load()
+{
+    return p_NDILib;
+}
 #endif
 

--- a/src/ofxNDIdynloader.h
+++ b/src/ofxNDIdynloader.h
@@ -30,7 +30,7 @@ public:
 
     // load library dynamically
     const NDIlib_v4* Load();
-    bool IsLoaded();
+    bool IsLoaded() { return m_bIsLoaded; }
 
 private :
 

--- a/src/ofxNDIdynloader.h
+++ b/src/ofxNDIdynloader.h
@@ -26,14 +26,19 @@ public:
     ofxNDIdynloader();
 	~ofxNDIdynloader();
 
+    const std::string FindRuntime();
+
     // load library dynamically
     const NDIlib_v4* Load();
+    bool IsLoaded();
 
 private :
 
 #if defined(TARGET_WIN32)
 	HMODULE m_hNDILib;
 #endif
+
+    bool m_bIsLoaded;
 	const NDIlib_v4* p_NDILib;
 
 };

--- a/src/ofxNDIdynloader.h
+++ b/src/ofxNDIdynloader.h
@@ -4,23 +4,31 @@
 #include <string>
 #include <vector>
 
+#include <boost/dll/import.hpp>         // for dll::import
+#include <boost/dll/shared_library.hpp> // for dll::shared_library
+#include <boost/function.hpp>
+
+namespace dll = boost::dll;
+
 #include "Processing.NDI.Lib.h" // NDI SDK
 
-typedef NDIlib_v4* (*NDIlib_v4_load_)(void);
+typedef NDIlib_v4* (NDIlib_v4_load_)(void);
 
 
 class ofxNDIdynloader
 {
-	const NDIlib_v4* p_NDILib;
-    bool             m_bWasLoaded;
-    
+    const NDIlib_v4* p_NDILib;
+
+    dll::shared_library dynlib;
     const std::string FindRuntime();
 
 public:
     ofxNDIdynloader();
+    ~ofxNDIdynloader();
 
     /** load library dynamically */
     const NDIlib_v4* Load();
+    const NDIlib_v4* Ref() { return p_NDILib; }
 };
 
 #endif // OFXNDIDYNLOADER_H

--- a/src/ofxNDIdynloader.h
+++ b/src/ofxNDIdynloader.h
@@ -1,13 +1,15 @@
 #ifndef ofxNDIdynloader_H
 #define ofxNDIdynloader_H
 
-#if defined(_WIN32)
+#include "ofxNDIplatforms.h"
+
+#if defined(TARGET_WIN32)
 #include <windows.h>
 #include <shlwapi.h>  // for path functions and HMODULE definition
 #include <Shellapi.h> // for shellexecute
 #pragma comment(lib, "shlwapi.lib")  // for path functions
 #pragma comment(lib, "Shell32.lib")  // for shellexecute
-#elif defined(__APPLE__) || defined(__linux__)
+#elif defined(TARGET_OSX) || defined(TARGET_LINUX)
 #include <dlfcn.h> // dynamic library loading in Linux
 #endif
 
@@ -29,7 +31,7 @@ public:
 
 private :
 
-#if defined(_WIN32)
+#if defined(TARGET_WIN32)
 	HMODULE m_hNDILib;
 #endif
 	const NDIlib_v4* p_NDILib;

--- a/src/ofxNDIplatforms.h
+++ b/src/ofxNDIplatforms.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#ifndef __ofxNDIplatforms_
+#define __ofxNDIplatforms_
+
+#if !defined(OF_VERSION_MAJOR) // guard aginst overriding OF constants if we are in a OF app
+
+//
+// Platform definitions
+//
+// Copied from Openframeworks platform defines in "ofConstants.h"
+//
+//-------------------------------
+//  find the system type --------
+//-------------------------------
+// 		helpful:
+// 		http://www.ogre3d.org/docs/api/html/OgrePlatform_8h-source.html
+//
+
+#if defined( __WIN32__ ) || defined( _WIN32 )
+#define TARGET_WIN32
+#elif defined( __APPLE_CC__)
+#define __ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORES 0
+#include <TargetConditionals.h>
+#if (TARGET_OS_IPHONE || TARGET_OS_IOS || TARGET_OS_SIMULATOR || TARGET_OS_IPHONE_SIMULATOR) && !TARGET_OS_TV && !TARGET_OS_WATCH
+#define TARGET_OF_IPHONE
+#define TARGET_OF_IOS
+#define TARGET_OPENGLES
+#include <unistd.h>
+#elif TARGET_OS_TV
+#define TARGET_OF_IOS
+#define TARGET_OF_TVOS
+#define TARGET_OPENGLES
+#include <unistd.h>
+#elif TARGET_OS_WATCH
+#define TARGET_OF_IOS
+#define TARGET_OF_WATCHOS
+#define TARGET_OPENGLES
+#include <unistd.h>
+#else
+#define TARGET_OSX
+#endif
+#elif defined (__ANDROID__)
+#define TARGET_ANDROID
+#define TARGET_OPENGLES
+#elif defined(__ARMEL__)
+#define TARGET_LINUX
+#define TARGET_OPENGLES
+#define TARGET_LINUX_ARM
+#elif defined(__EMSCRIPTEN__)
+#define TARGET_EMSCRIPTEN
+#define TARGET_OPENGLES
+#define TARGET_NO_THREADS
+#define TARGET_PROGRAMMABLE_GL
+#define TARGET_IMPLEMENTS_URL_LOADER
+#else
+#define TARGET_LINUX
+#endif
+//-------------------------------
+
+// Could be extended - see ofConstants.h
+
+#endif // !defined(OF_VERSION_MAJOR)
+
+#endif
+

--- a/src/ofxNDIplatforms.h
+++ b/src/ofxNDIplatforms.h
@@ -5,8 +5,14 @@
 
 #if !defined(OF_VERSION_MAJOR) // guard aginst overriding OF constants if we are in a OF app
 
+// error, warning and out streams for non-OF apps all map to `cout`
+#define ERRS cout
+#define WARNS cout
+#define OUTS cout
+
+
 //
-// Platform definitions
+//	Platform definitions
 //
 // Copied from Openframeworks platform defines in "ofConstants.h"
 //
@@ -60,6 +66,13 @@
 //-------------------------------
 
 // Could be extended - see ofConstants.h
+
+#elif defined(OF_VERSION_MAJOR) // we are being compiled from an OF applications
+
+// error, warning and out streams for non-OF apps all map to `cout`
+#define ERRS ofLogError()
+#define WARNS ofLogWarning()
+#define OUTS ofLogNotice()
 
 #endif // !defined(OF_VERSION_MAJOR)
 

--- a/src/ofxNDIplatforms.h
+++ b/src/ofxNDIplatforms.h
@@ -19,6 +19,7 @@
 
 #if defined( __WIN32__ ) || defined( _WIN32 )
 #define TARGET_WIN32
+#define TARGET_WINDOWS
 #elif defined( __APPLE_CC__)
 #define __ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORES 0
 #include <TargetConditionals.h>

--- a/src/ofxNDIsend.cpp
+++ b/src/ofxNDIsend.cpp
@@ -101,12 +101,16 @@ ofxNDIsend::ofxNDIsend()
 	m_AudioTimecode = NDIlib_send_timecode_synthesize; // Timecode (synthesized for us !)
 	m_AudioData = NULL; // Audio buffer
 
-	// Find and load the Newtek NDI dll
-    p_NDILib = libloader.Load();
-	if(p_NDILib) {
-		m_bNDIinitialized = true;
-		std::cout << "NDI runtime has been initialized..." << std::endl;
-	}
+    // if not already loaded
+    if(!libloader.IsLoaded()) {
+        // find and load the Newtek NDI dll
+        p_NDILib = libloader.Load();
+        if(p_NDILib) {
+            m_bNDIinitialized = true;
+            std::cout << "NDI runtime has been initialized..." << std::endl;
+        }
+    }
+
 }
 
 

--- a/src/ofxNDIsender.cpp
+++ b/src/ofxNDIsender.cpp
@@ -192,8 +192,9 @@ bool ofxNDIsender::SendImage(ofTexture tex, bool bInvert)
 	if (!ndiBuffer[0].isAllocated() || !ndiBuffer[1].isAllocated())
 		return false;
 
-	// Quit if the texture is not RGBA
-	if (tex.getTextureData().glInternalFormat != GL_RGBA)
+    // Quit if the texture is not RGBA or RGB
+    int format = tex.getTextureData().glInternalFormat;
+    if ( (format != GL_RGBA) && (format != GL_RGB) )
 		return false;
 
 	unsigned int width = (unsigned int)tex.getWidth();

--- a/src/ofxNDIutils.cpp
+++ b/src/ofxNDIutils.cpp
@@ -42,6 +42,7 @@
 
 */
 #include "ofxNDIutils.h"
+#include <stdint.h> // ints of known sizes, standard library
 
 
 // _rotl replacement
@@ -220,8 +221,8 @@ namespace ofxNDIutils {
 		for (unsigned int y = 0; y < height; y++) {
 
 			// Start of buffer
-			auto source = static_cast<const unsigned __int32 *>(rgba_source);; // unsigned int = 4 bytes
-			auto dest = static_cast<unsigned __int32 *>(bgra_dest);
+            auto source = static_cast<const uint32_t *>(rgba_source); // unsigned int = 4 bytes
+            auto dest = static_cast<uint32_t *>(bgra_dest);
 
 			// Increment to current line
 			if (bInvert) {

--- a/src/ofxNDIutils.h
+++ b/src/ofxNDIutils.h
@@ -45,8 +45,6 @@
 #elif defined(_WIN32)
 #include <windows.h>
 #include <intrin.h> // for _movsd
-#else // Linux
-#include <xmmintrin.h>
 #endif
 
 #include <cstring>


### PR DESCRIPTION
- removed BOOST dependency
- removed __int32 (win specific) and changed for <stdint.h> known-size integers
- brought back `ofxNDIplatforms.h` to have a bit of leverage over the OF/no-OF compilation modes (it was a good idea, just needed a slight tweak)
- added flag to dynloader to signify load status (this should probably be a singleton)
- tested on _x64_ and _aarch64_
