### PR TITLE
missing std:: for TARGET_LINUX

### DIFF
--- a/src/ofxNDIdynloader.cpp
+++ b/src/ofxNDIdynloader.cpp
@@ -162,12 +162,12 @@ const NDIlib_v4* ofxNDIdynloader::Load()
 		return p_NDILib;
 
     std::string ndi_path = FindRuntime();
-    OUTS << "NDI runtime location " << ndi_path << endl;
+    OUTS << "NDI runtime location " << ndi_path << std::endl;
 
     // attempt to load the library and get a handle to it
     void *m_hNDILib = dlopen(ndi_path.c_str(), RTLD_LOCAL | RTLD_LAZY);
     if (!m_hNDILib) {
-        ERRS << "Couldn't load dynamic library at: " << ndi_path << endl;
+        ERRS << "Couldn't load dynamic library at: " << ndi_path << std::endl;
         return nullptr;
     }
 
@@ -183,7 +183,7 @@ const NDIlib_v4* ofxNDIdynloader::Load()
             dlclose(m_hNDILib);
 			m_hNDILib = NULL;
         }
-        WARNS << "Please re-install the NewTek NDI Runtimes from " << NDILIB_REDIST_URL << " to use this application" << endl;
+        WARNS << "Please re-install the NewTek NDI Runtimes from " << NDILIB_REDIST_URL << " to use this application" << endl::endl;
         return nullptr;
     }
 


### PR DESCRIPTION
ofxNDIdynloader::Load()
- TARGET_LINUX: Added Missing std:: for the std::endl output.