### PR TITLE
Default case

### DIFF
--- a/src/ofxNDIreceive.cpp
+++ b/src/ofxNDIreceive.cpp
@@ -1102,7 +1102,9 @@ bool ofxNDIreceive::ReceiveImage(unsigned int &width, unsigned int &height)
 					bReceiverConnected = false;
 				}
 				break; // endif NDIlib_frame_type_video
-
+				
+			default :
+				break;
 		} // end switch frame type
 	} // endif pNDI_recv
 	else {


### PR DESCRIPTION
so it doesn't complain about missing NDIlib_frame_type_max in switch