### PR TITLE
exclude shaders and readme

### DIFF
--- a/addon_config.mk
+++ b/addon_config.mk
@@ -76,6 +76,8 @@ common:
 	# ADDON_LIBS += libs/opencv/lib/linuxarmv6l/libopencv_calib3d.a
 	# ...
 
+	ADDON_SOURCES_EXCLUDE = src/shaders/%
+
 linux64:
 linux:
 win_cb:


### PR DESCRIPTION
with this change project generator don't try to include shaders and txt file in the sources to compile (at least in macOS)