### PR TITLE
macos: Fix compiler flag passed to linker

### DIFF
--- a/addon_config.mk
+++ b/addon_config.mk
@@ -77,7 +77,7 @@ common:
 	# ...
 
 osx:
-	ADDON_LDFLAGS = -Xlinker -rpath -Xlinker @executable_path
+        ADDON_LDFLAGS = -rpath @executable_path
 linux64:
 linux:
 linuxarmv6l:


### PR DESCRIPTION
Fixes compilation on QtCreator. Also tested on Xcode 12.4 and makefiles.

Related to commit 5a751a9

Discussion: https://github.com/leadedge/ofxNDI/commit/5a751a968c93dfbdf5849d6a9f66f0d71a56fd87